### PR TITLE
Update slider.lua

### DIFF
--- a/slider.lua
+++ b/slider.lua
@@ -24,6 +24,8 @@ return function(core, info, ...)
 			fraction = math.min(1, math.max(0, (mx - x) / w))
 		end
 		local v = fraction * (info.max - info.min) + info.min
+		v = math.floor((v/info.step) + 0.5) * info.step			--Snaps slider to nearest step interval.
+		fraction = v / (info.max - info.min) + info.min			--Updates slider drawing during mouse drag.
 		if v ~= info.value then
 			info.value = v
 			value_changed = true


### PR DESCRIPTION
Sliders don't respect their `info.step` when dragged by the mouse.
The first new line rounds `value` to the nearest step.
The second new line also rounds `fraction` to the nearest step which is used for drawing. Skipping this line means the slider follows the mouse while being dragged but snaps back on release (the value is still always snapped).

The `+0.5` is used to round it to the nearest value, removing it will always round down.
`value_changed` is only updated if the value is actual changed; dragging the mouse less then `info.step/2` will not cause an update.